### PR TITLE
fix markdown of license file to be markdownlint compliant

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,12 +1,12 @@
-**Royalty-free Software provided by Siemens on sharing platforms for developers/users of Siemens products**
+# Royalty-free Software provided by Siemens on sharing platforms for developers/users of Siemens products
 
-**1. General information: Software in source code and object code**
+## 1. General information: Software in source code and object code
 
-**1.1 Use of the Software**
+### 1.1 Use of the Software
 
 Siemens AG and/or a subsidiary of Siemens AG ("Siemens") provides You royalty-free container images, application examples, sample code and software development kits ("Software") through sharing platforms (e.g. GitHub, DockerHub, NuGet, etc.). The Software shall only be used for the development and test of software which can be used with Siemens products ("intended purpose"). The Software is non-binding and makes no claim to completeness or functionality. The Software merely offers help with typical tasks and provides an environment for developing and testing applications and other software. You Yourself are responsible for the proper and safe operation of Your products in accordance with applicable regulations and must also check the function of the results of the Software and customize Your products. Siemens reserves the right to make changes to the Software at any time without notice. Software may be provided in object code and/or source code format. Unless explicitly granted in the open source license according to article 2, You shall not decompile, translate, extract, modify or distribute the Software.
 
-**1.2 Security information**
+### 1.2 Security information
 
 Siemens provides products and solutions with industrial security functions that support the secure operation of plants, systems, machines and networks.
 
@@ -16,15 +16,15 @@ Customers are responsible for preventing unauthorized access to their plants, sy
 For additional information on industrial security measures that may be implemented, please visit
 <https://www.siemens.com/industrialsecurity>.
 
-**1.3 Compliance with Export Control Regulations**
+### 1.3 Compliance with Export Control Regulations
 
 You shall comply with all applicable sanctions, embargoes and (re-)export control regulations, and, in any event, with those of the European Union and the United States of America (collectively "Export Regulations"). In particular, the information, software and documentation provided by Siemens (collectively "Licensed Material") shall not be used, accessed or transferred, unless permitted by the Export Regulations or respective governmental licenses or approvals, (i) in or to any location prohibited by or subject to comprehensive sanctions (currently Russia, Cuba, Iran, North Korea, Syria, and the Crimea region of Ukraine, Donetsk and Luhansk regions of Ukraine) or license requirements according to the Export Regulations; (ii) by or to any individual or entity designated on a sanctioned party list of the Export Regulations; (iii) for any purpose prohibited by the Export Regulations (e.g. use in connection with armaments, nuclear technology or weapons); or (iv) to upload any content unless it is noncontrolled (e .g. in the EU: AL = N; in the U.S.: ECCN = N or EAR99). If required to enable authorities or Siemens to conduct export control checks, You, upon request by Siemens, shall promptly provide Siemens with all information pertaining to You, the intended use and the location of use of the Licensed Material. Siemens shall not be obligated to fulfill this Agreement if such fulfillment is prevented by any impediments arising out of national or international foreign trade or customs requirements or any embargoes or other sanctions.
 
-**1.4 Hyperlinks and third party content**
+### 1.4 Hyperlinks and third party content
 
 The Software and / or the documentation may contain hyperlinks to the web pages of third parties or references to third party content. Siemens shall have no liability for the contents of such web pages and does not make representations about or endorse such web pages or their contents as its own, as Siemens does not control the information on such web pages and is not responsible for the contents and information given thereon. The use of such web pages shall be Your sole risk.
 
-**2. Open Source License for Software provided in source code and the generated source code**
+## 2. Open Source License for Software provided in source code and the generated source code
 
 In case the Software contains or generates source code the following open source license (Open license terms) shall apply for such source code:
 
@@ -42,15 +42,15 @@ To the extent there is a conflict between this terms and conditions and the Open
 
 You acknowledge and agree that Siemens provides no warranties, express or implied, for the open source software itself. Siemens shall have no liability nor shall Siemens provide any indemnification whatsoever in respect of Your distribution or modification of the open source software.
 
-**3. Software provided in object code**
+## 3. Software provided in object code
 
 For all portions of the Software that are provided in object code format the following conditions shall apply ("Royalty-Free Siemens Software Conditions"):
 
-**3.1 License Grant**
+### 3.1 License Grant
 
 Siemens grants You the royalty-free, non-exclusive, non-sublicensable and non-transferable right to use, have used the Software by technically trained personnel and for the intended purpose only.
 
-**3.2 Included third-party software components**
+### 3.2 Included third-party software components
 
 Insofar as Open Source Software is included in the Software, such Open Source Software is listed in the Readme_OSS file of the Software. You are entitled to use the Open Source Software in accordance with the respective applicable license conditions of the Open Source Software. These OSS license conditions are included with Software and shall prevail over these Royalty-Free Siemens Software Conditions. The Open Source Software license conditions shall have priority also in relation to the proprietary Siemens components insofar as the Open Source Software license conditions grant You certain rights of use on the basis of the connection of OSS components with proprietary Siemens components.
 
@@ -58,7 +58,7 @@ Siemens shall make available to You, at Your request, the Open Source Software s
 
 The Software may, in addition to Open Source Software, contain other licensed software, i.e. software which was not developed by Siemens itself, but which Siemens has obtained from third parties, e.g. Microsoft Ireland Operations Ltd, under a license. If You shall receive in such case the conditions of the respective licensor of the licensed software in the Readme_OSS file, these shall apply to the liability of the licensor in relation to You. In terms of the liability of Siemens to You, these Royalty-Free Siemens Software Conditions shall apply in each case.
 
-**3.3 Disclaimer of liability**
+### 3.3 Disclaimer of liability
 
 Siemens shall not assume any liability, for any legal reason whatsoever, including, without limitation, liability for the usability, availability, completeness and freedom from defects of the Software as well as for the Licensed Material and any damage caused thereby. This shall not apply in cases of mandatory liability, for example product liability law or in cases of intent, gross negligence, or culpable loss of life, bodily injury or damage to health, non-compliance with a guarantee, fraudulent non-disclosure of a defect, or culpable breach of material contractual obligations. Claims for damages arising from a breach of material contractual obligations shall however be limited to the foreseeable damage typical of the type of agreement, unless liability arises from intent or gross negligence or is based on loss of life, bodily injury or damage to health. The foregoing provisions do not imply any change in the burden of proof to Your detriment. You shall indemnify Siemens against existing or future claims of third parties in this connection except where Siemens is mandatorily liable.
 


### PR DESCRIPTION
Hi ToA,

I am using markdownlint (a very common extension) and the License.md file violates some basic rules.

Here is a suggestion for a markdownlint compliant version. I did of course change nothing about the content of the license.